### PR TITLE
supports unverified ssl certs (self-signed) to WebsocketTransport

### DIFF
--- a/socketIO_client/transports.py
+++ b/socketIO_client/transports.py
@@ -6,6 +6,7 @@ import re
 import requests
 import six
 import socket
+import ssl
 import time
 import websocket
 
@@ -134,7 +135,10 @@ class WebsocketTransport(_AbstractTransport):
 
         try:
             _log.debug("[websocket] Connecting");
-            self._connection = websocket.create_connection(self._url)
+            if "verify" in kw and not kw["verify"]:
+                self._connection = websocket.create_connection(self._url, sslopt={"cert_reqs": ssl.CERT_NONE});
+            else:
+                self._connection = websocket.create_connection(self._url);
         except socket.timeout as e:
             raise ConnectionError(e)
         except socket.error as e:


### PR DESCRIPTION
 SocketIOClient has an option for determining whether it should verify the ssl cert from the server. WebsocketTransport ignored this option. This patch correctly uses the "verify" parameter in the WebsocketTransport.
